### PR TITLE
Reload the SSH config to enable custom ports

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,3 +148,7 @@ ufw --force enable
 
 # Reboot the server
 # reboot
+
+# Since we not longer reboot here, reload the SSH config to active the
+# custom port if selected
+systemctl reload sshd


### PR DESCRIPTION
Since we disabled the reboot at the end of the script, if you use a custom SSH port you can not longer connect to the VPS until you reboot it from the hoster interface.