### PR TITLE
Add .bash_aliases support to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,24 @@ ufw default deny incoming
 ufw default allow outgoing
 ufw --force enable
 
+# Create aliases for commonly use smartcash-cli commands to ~/.bash_alises
+if [ -e ~/.bash_alises ]
+then
+    echo "~/.bash_alises exists, not adding additional aliases."
+else
+    echo "Adding aliases for common smartcash-cli commands to ~/.bash_alises"
+    echo "
+    alias getinfo='smartcash-cli getinfo'
+    alias nodestatus='smartcash-cli smartnode status'
+    alias syncstatus='smartcash-cli snsync status'
+    alias restartnode='smartcash-cli stop && sleep 5 && smartcashd'
+    " > ~/.bash_alises
+    echo "getinfo for 'smartcash-cli getinfo'"
+    echo "nodestatus for 'smartcash-cli smartnode status'"
+    echo "syncstatus for 'smartcash-cli syncstatus'"
+    echo "restartnode for 'smartcash-cli stop && sleep 5 && smartcashd'"
+fi
+
 # Reboot the server
 # reboot
 


### PR DESCRIPTION
Added section to create a few aliases for commonly used smartcash-cli support commands.  Currently it will only create ~/.bash_aliases if it doesn't already exist.  

Aliases added: getinfo, nodestatus, syncstatus, and restartnode